### PR TITLE
Legend should describe the reason for colour

### DIFF
--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -42,10 +42,12 @@ const Home = () => {
       <div>
         <ColorIndicator backgroundColor="#FFDAD2" />{' '}
         <Typography variant="caption" style={{ marginRight: 16 }}>
-          90% Confidence Interval
+          R<sub>t</sub> &gt; 1
         </Typography>
         <ColorIndicator backgroundColor="#C7F5C0" />{' '}
-        <Typography variant="caption">90% Confidence Interval</Typography>
+        <Typography variant="caption">
+	  R<sub>t</sub> &lt; 1
+	</Typography>
       </div>
     </div>
   );


### PR DESCRIPTION
I didn't setup an environment so I haven't actually tested it :)

Right now it shows both Red and Green as representing the same confidence interval.  Should the legend instead describe why these bars are different colours? 